### PR TITLE
STB-56: Create Database Schema Migrations

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,11 @@
+# Database
+
+This package contains the migrations needed in order to initialize the application's database.
+
+## Migrations
+
+They are located in the `migrations` folder and should be run sequentially in (lexicographical) order to achieve the correct state.
+
+It's assumed they will run against a [Supabase](https://supabase.com/) schema, which already contains some functionality not native to Postgres (e.g. the `storage` schema).
+
+When creating new migrations, keep them named appropriately, that is, with a serial numeric prefix, and underscore-separated (_) words.

--- a/packages/db/migrations/0001_servers.sql
+++ b/packages/db/migrations/0001_servers.sql
@@ -1,0 +1,4 @@
+create table servers (
+    id bigint primary key,
+    name text not null 
+);

--- a/packages/db/migrations/0002_tokens.sql
+++ b/packages/db/migrations/0002_tokens.sql
@@ -1,0 +1,4 @@
+create table tokens (
+    id text not null primary key,
+    metadata jsonb not null
+);

--- a/packages/db/migrations/0003_server_tokens.sql
+++ b/packages/db/migrations/0003_server_tokens.sql
@@ -1,0 +1,10 @@
+create table server_tokens (
+    server_id bigint not null references servers (id),
+    token_id text not null references tokens (id),
+
+    primary key (server_id, token_id)
+);
+
+--   As the server_id appears first on the table declaration, we would need a second
+-- index if we want to search by token_id alone, e.g. 
+-- create index index_server_tokens_token_id on server_tokens (token_id);

--- a/packages/db/migrations/0004_wallets.sql
+++ b/packages/db/migrations/0004_wallets.sql
@@ -1,0 +1,11 @@
+create table wallets (
+    user_id bigint not null,
+    server_id bigint not null references servers (id),
+    wallet text not null,
+
+    primary key (user_id, server_id)
+);
+
+--   As the user_id appears first on the table declaration, we would need a second
+-- index if we want to search by server_id alone, e.g. 
+-- create index index_wallets_server_id on wallets (server_id);


### PR DESCRIPTION
Creates the first 4 schema migrations for the project, under the repository package `db`. Follows the specification from the diagram embedded in the [project's Notion page](https://www.notion.so/The-NEAR-Tipping-bot-aa665284ca4b4c86ac6a1890b80c98ab).

It's currently deployed to my personal Supabase account
- URL: [lizvrgxyxanjqyltiyyy.supabase.co](https://lizvrgxyxanjqyltiyyy.supabase.co)
- no-role `apiKey`: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxpenZyZ3h5eGFuanF5bHRpeXl5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2NjY5ODM3MTgsImV4cCI6MTk4MjU1OTcxOH0._NR1y1HbtCQqMR_cOR9h2V6s0OeAO2jHiCYEXQytMG8`

The composite primary keys were defined in the order which made more sense at first (i.e. no need to query all wallets in a server, but it's important to be able to query all of an user's wallets). As the project develops, it can be necessary to create additional indexes. In order to avoid bloat, I've refrained from creating indexes which we still aren't sure will be required.
