### PR TITLE
STB-97(fix): show user wallet

### DIFF
--- a/packages/bot/src/commands/verifyWallet.js
+++ b/packages/bot/src/commands/verifyWallet.js
@@ -12,7 +12,7 @@ module.exports = {
 
     const userWallet = await findUserWallet(id, serverId);
 
-    if (!userWallet) {
+    if (!userWallet.wallet) {
       await interaction.reply({
         content:
           "There is no wallet registred. Please use /setwallet to save your wallet",
@@ -22,7 +22,7 @@ module.exports = {
     }
 
     await interaction.reply({
-      content: `Hey you ${username}, your wallet is ${userWallet.node.wallet}`,
+      content: `Hey you ${username}, your wallet is ${userWallet.wallet}`,
       ephemeral: true,
     });
   },


### PR DESCRIPTION
error when verifying and printing the user wallet - was printing the object instead of just the wallet

### What does it do?

Changes the verification and printing of the user wallet to actually verify the wallet instead if the object 

### Does it close any issues?

Closes STB-97