### PR TITLE
 STB-130 modificar comando send

### DIFF
--- a/packages/bot/src/commands/send.js
+++ b/packages/bot/src/commands/send.js
@@ -1,7 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 const getSendParameters = require("../graphql/queries/getSendParameters");
 const listServerTokens = require("../graphql/queries/listServerTokens");
-const findUserWallet = require("../graphql/queries/findUserWallet");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -60,8 +59,6 @@ module.exports = {
     const amount = interaction.options.getString("amount");
     const receiver = interaction.options.getUser("receiver");
 
-    const receiverWallet = await findUserWallet(receiver.id, serverId);
-
     const { token, wallet } = await getSendParameters(
       serverId,
       receiver.id,
@@ -87,13 +84,17 @@ module.exports = {
       return;
     }
 
+    const linkToTransfer = `Click the link to transfer: https://peterthebot.com/transaction?token=${
+      token.id
+    }&amount=${amount.replace(
+      /,/g,
+      "."
+    )}&receiver=${wallet}&burner=${burnWallet}&receiver_id=${
+      receiver.id
+    }&sender_id=${sender.id}&server_id=${serverId}`;
+
     await interaction.reply({
-      content: `Click the link to transfer: https://peterthebot.com/transaction?token=${
-        token.id
-      }&amount=${amount.replace(
-        /,/g,
-        "."
-      )}&receiver=${wallet}&burner=${burnWallet}`,
+      content: linkToTransfer,
       ephemeral: true,
     });
   },


### PR DESCRIPTION
@veigajoao Altered contract interface to include sender_discord,    receiver_discord, server_discord, which are String parameters and should receive the respective discord IDs.

Methods:
`transfer_payment`
Arguments are now:
receiver: AccountId,
sender_discord: String,
receiver_discord: String,
server_discord: String,

`ft_on_transfer`
Arguments are still the same, however, the message parameter was changd. Before, it was the stringfied version of the JS object:
`{ receiver: string }`, now it is the stringfied version of the following JS object:
```
{
    receiver: string,
    sender_discord: string,
    receiver_discord: string,
    server_discord: string,
}
```

Bot commands, URL query string and front end calls must still be altered accordingly @alexandrearaujoo 